### PR TITLE
Move to undetected-chromedriver library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,12 @@ pyOpenSSL==21.0.0
 pyparsing==3.0.6
 PySocks==1.7.1
 selenium==4.1.0
-selenium-wire==4.5.6
 six==1.16.0
 sniffio==1.2.0
 sortedcontainers==2.4.0
 trio==0.19.0
 trio-websocket==0.9.2
+undetected-chromedriver==3.0.6
 urllib3==1.26.7
 wsproto==1.0.0
 zstandard==0.16.0

--- a/southwest-headers.py
+++ b/southwest-headers.py
@@ -8,8 +8,8 @@ import os
 import random
 import string
 import sys
+import seleniumwire.undetected_chromedriver.v2 as uc
 from pathlib import Path
-from seleniumwire import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -20,7 +20,7 @@ first_name = ''.join(random.choices(string.ascii_lowercase, k=random.randrange(4
 last_name = ''.join(random.choices(string.ascii_lowercase, k=random.randrange(4,10))).capitalize()
 output_file = sys.argv[1] if len(sys.argv) > 1 else "southwest_headers.json"
 
-chrome_options = Options()
+chrome_options = uc.ChromeOptions()
 chrome_options.headless = True
 
 # the headless option adds HeadlessChrome to the user agent which causes southwest to return invalid headers. so need to set a user agent that appears like a normal web browser.
@@ -34,7 +34,7 @@ chrome_options.add_argument('--disable-dev-shm-usage')
 # fixes issue if user doesn't have write permissions to default storage location
 seleniumwire_options = { 'request_storage': 'memory' }
 
-driver = webdriver.Chrome(os.getcwd() + "/chromedriver", options=chrome_options, seleniumwire_options=seleniumwire_options)
+driver = uc.Chrome(options=chrome_options, seleniumwire_options=seleniumwire_options, version_main=96)
 driver.scopes = [ "page\/check-in" ]    # only capture request URLs matching this regex
 
 driver.get("https://mobile.southwest.com/check-in")


### PR DESCRIPTION
This is to swap the dependencies on selenium-wire to undetected-chromedriver, making it easier to spin up this project without having to manually edit the chromedriver binary.